### PR TITLE
Add admin mode for teacher-only registration management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+passlib[bcrypt]

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,15 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import os
+import json
+import secrets
 from pathlib import Path
+from passlib.hash import bcrypt
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +22,86 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# --- Auth setup ---
+
+TEACHERS_FILE = current_dir / "teachers.json"
+
+# In-memory session store: token -> username
+_sessions: dict[str, str] = {}
+
+
+def _load_and_migrate_teachers() -> dict:
+    """Load teachers.json, hashing any plain-text passwords on first run."""
+    with open(TEACHERS_FILE, "r") as f:
+        data = json.load(f)
+
+    changed = False
+    for teacher in data["teachers"]:
+        if teacher["password"].startswith("plain:"):
+            plain = teacher["password"][len("plain:"):]
+            teacher["password"] = bcrypt.hash(plain)
+            changed = True
+
+    if changed:
+        with open(TEACHERS_FILE, "w") as f:
+            json.dump(data, f, indent=2)
+
+    return {t["username"]: t["password"] for t in data["teachers"]}
+
+
+_teachers: dict[str, str] = _load_and_migrate_teachers()
+
+security = HTTPBearer(auto_error=False)
+
+
+def get_current_teacher(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+) -> str | None:
+    """Return the logged-in teacher's username, or None if not authenticated."""
+    if credentials is None:
+        return None
+    return _sessions.get(credentials.credentials)
+
+
+def require_teacher(
+    teacher: str | None = Depends(get_current_teacher),
+) -> str:
+    """Dependency that raises 401 if the request is not from an authenticated teacher."""
+    if teacher is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return teacher
+
+
+# --- Auth endpoints ---
+
+@app.post("/auth/login")
+def login(username: str, password: str):
+    """Log in as a teacher. Returns a session token."""
+    hashed = _teachers.get(username)
+    if hashed is None or not bcrypt.verify(password, hashed):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = secrets.token_urlsafe(32)
+    _sessions[token] = username
+    return {"token": token, "username": username}
+
+
+@app.post("/auth/logout")
+def logout(teacher: str = Depends(require_teacher),
+           credentials: HTTPAuthorizationCredentials | None = Depends(security)):
+    """Log out the current teacher session."""
+    if credentials:
+        _sessions.pop(credentials.credentials, None)
+    return {"message": f"Logged out {teacher}"}
+
+
+@app.get("/auth/status")
+def auth_status(teacher: str | None = Depends(get_current_teacher)):
+    """Return the current auth status."""
+    return {"logged_in": teacher is not None, "username": teacher}
+
+
+# --- Activity data ---
 
 # In-memory activity database
 activities = {
@@ -89,44 +173,35 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
+def signup_for_activity(activity_name: str, email: str,
+                        teacher: str = Depends(require_teacher)):
+    """Sign up a student for an activity (teachers only)"""
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
     activity = activities[activity_name]
 
-    # Validate student is not already signed up
     if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Add student
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(status_code=400, detail="Activity is full")
+
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
+def unregister_from_activity(activity_name: str, email: str,
+                             teacher: str = Depends(require_teacher)):
+    """Unregister a student from an activity (teachers only)"""
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
     activity = activities[activity_name]
 
-    # Validate student is signed up
     if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Remove student
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -2,26 +2,106 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
+  const signupContainer = document.getElementById("signup-container");
   const messageDiv = document.getElementById("message");
+  const authBtn = document.getElementById("auth-btn");
+  const authUsername = document.getElementById("auth-username");
 
-  // Function to fetch activities from API
+  // --- Auth state ---
+  let authToken = localStorage.getItem("authToken");
+  let loggedInUser = localStorage.getItem("authUser");
+
+  function updateAuthUI() {
+    if (authToken && loggedInUser) {
+      authUsername.textContent = `\u{1F464} ${loggedInUser}`;
+      authUsername.classList.remove("hidden");
+      authBtn.textContent = "Logout";
+      authBtn.onclick = handleLogout;
+      signupContainer.classList.remove("hidden");
+    } else {
+      authUsername.textContent = "";
+      authUsername.classList.add("hidden");
+      authBtn.textContent = "\u{1F464} Login";
+      authBtn.onclick = openLoginModal;
+      signupContainer.classList.add("hidden");
+    }
+    fetchActivities();
+  }
+
+  // --- Login modal ---
+  window.openLoginModal = function () {
+    document.getElementById("login-modal").classList.remove("hidden");
+    document.getElementById("modal-overlay").classList.remove("hidden");
+    document.getElementById("login-username").focus();
+  };
+
+  window.closeLoginModal = function () {
+    document.getElementById("login-modal").classList.add("hidden");
+    document.getElementById("modal-overlay").classList.add("hidden");
+    document.getElementById("login-error").classList.add("hidden");
+    document.getElementById("login-form").reset();
+  };
+
+  document.getElementById("login-form").addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const username = document.getElementById("login-username").value;
+    const password = document.getElementById("login-password").value;
+    const errorDiv = document.getElementById("login-error");
+
+    try {
+      const response = await fetch(
+        `/auth/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        { method: "POST" }
+      );
+      const result = await response.json();
+
+      if (response.ok) {
+        authToken = result.token;
+        loggedInUser = result.username;
+        localStorage.setItem("authToken", authToken);
+        localStorage.setItem("authUser", loggedInUser);
+        closeLoginModal();
+        updateAuthUI();
+      } else {
+        errorDiv.textContent = result.detail || "Login failed";
+        errorDiv.classList.remove("hidden");
+      }
+    } catch {
+      errorDiv.textContent = "Login failed. Please try again.";
+      errorDiv.classList.remove("hidden");
+    }
+  });
+
+  async function handleLogout() {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+    } catch { /* ignore */ }
+    authToken = null;
+    loggedInUser = null;
+    localStorage.removeItem("authToken");
+    localStorage.removeItem("authUser");
+    updateAuthUI();
+  }
+
+  // --- Activities ---
   async function fetchActivities() {
     try {
       const response = await fetch("/activities");
       const activities = await response.json();
 
-      // Clear loading message
       activitiesList.innerHTML = "";
+      // Reset select options
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
-      // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
         activityCard.className = "activity-card";
 
-        const spotsLeft =
-          details.max_participants - details.participants.length;
+        const spotsLeft = details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
         const participantsHTML =
           details.participants.length > 0
             ? `<div class="participants-section">
@@ -30,7 +110,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        authToken
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">&#10060;</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -49,25 +133,23 @@ document.addEventListener("DOMContentLoaded", () => {
 
         activitiesList.appendChild(activityCard);
 
-        // Add option to select dropdown
         const option = document.createElement("option");
         option.value = name;
         option.textContent = name;
         activitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      if (authToken) {
+        document.querySelectorAll(".delete-btn").forEach((button) => {
+          button.addEventListener("click", handleUnregister);
+        });
+      }
     } catch (error) {
-      activitiesList.innerHTML =
-        "<p>Failed to load activities. Please try again later.</p>";
+      activitiesList.innerHTML = "<p>Failed to load activities. Please try again later.</p>";
       console.error("Error fetching activities:", error);
     }
   }
 
-  // Handle unregister functionality
   async function handleUnregister(event) {
     const button = event.target;
     const activity = button.getAttribute("data-activity");
@@ -75,11 +157,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/unregister?email=${encodeURIComponent(email)}`,
+        `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: { Authorization: `Bearer ${authToken}` },
         }
       );
 
@@ -88,8 +169,6 @@ document.addEventListener("DOMContentLoaded", () => {
       if (response.ok) {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
@@ -97,11 +176,7 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
     } catch (error) {
       messageDiv.textContent = "Failed to unregister. Please try again.";
       messageDiv.className = "error";
@@ -110,7 +185,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
@@ -119,11 +193,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/signup?email=${encodeURIComponent(email)}`,
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: { Authorization: `Bearer ${authToken}` },
         }
       );
 
@@ -133,8 +206,6 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
@@ -142,11 +213,7 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
     } catch (error) {
       messageDiv.textContent = "Failed to sign up. Please try again.";
       messageDiv.className = "error";
@@ -155,6 +222,26 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  // Initialize app
-  fetchActivities();
+  // Validate stored token on load
+  async function validateToken() {
+    if (!authToken) {
+      updateAuthUI();
+      return;
+    }
+    try {
+      const response = await fetch("/auth/status", {
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+      const result = await response.json();
+      if (!result.logged_in) {
+        authToken = null;
+        loggedInUser = null;
+        localStorage.removeItem("authToken");
+        localStorage.removeItem("authUser");
+      }
+    } catch { /* ignore */ }
+    updateAuthUI();
+  }
+
+  validateToken();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,29 +10,54 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-area">
+        <span id="auth-username" class="hidden"></span>
+        <button id="auth-btn" onclick="openLoginModal()">&#128100; Login</button>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3 id="modal-title">Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="login-username">Username:</label>
+            <input type="text" id="login-username" required autocomplete="username" />
+          </div>
+          <div class="form-group">
+            <label for="login-password">Password:</label>
+            <input type="password" id="login-password" required autocomplete="current-password" />
+          </div>
+          <div id="login-error" class="error hidden"></div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button type="button" class="secondary" onclick="closeLoginModal()">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
+    <div id="modal-overlay" class="hidden" onclick="closeLoginModal()"></div>
 
     <main>
       <section id="activities-container">
         <h3>Available Activities</h3>
         <div id="activities-list">
-          <!-- Activities will be loaded here -->
           <p>Loading activities...</p>
         </div>
       </section>
 
-      <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+      <section id="signup-container" class="hidden">
+        <h3>Sign Up a Student</h3>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
-            <input type="email" id="email" required placeholder="your-email@mergington.edu" />
+            <input type="email" id="email" required placeholder="student@mergington.edu" />
           </div>
           <div class="form-group">
             <label for="activity">Select Activity:</label>
             <select id="activity" required>
               <option value="">-- Select an activity --</option>
-              <!-- Activity options will be loaded here -->
             </select>
           </div>
           <button type="submit">Sign Up</button>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,8 +16,9 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
-  padding: 20px 0;
+  padding: 20px 60px 20px 20px;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
@@ -26,6 +27,82 @@ header {
 
 header h1 {
   margin-bottom: 10px;
+}
+
+#auth-area {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#auth-username {
+  font-size: 14px;
+  color: #c5cae9;
+}
+
+#auth-btn {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  padding: 6px 12px;
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+#auth-btn:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+/* Modal */
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  border-radius: 8px;
+  padding: 30px;
+  z-index: 1000;
+  width: 90%;
+  max-width: 380px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}
+
+.modal h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 10px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 15px;
+}
+
+.modal-actions button {
+  flex: 1;
+}
+
+button.secondary {
+  background-color: #757575;
+}
+
+button.secondary:hover {
+  background-color: #9e9e9e;
+}
+
+#modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 999;
 }
 
 main {
@@ -74,7 +151,6 @@ section h3 {
   margin-bottom: 8px;
 }
 
-/* New styles for participants section */
 .participants-container {
   margin-top: 15px;
   padding-top: 12px;
@@ -100,7 +176,6 @@ section h3 {
   justify-content: space-between;
 }
 
-/* Remove the bullet point pseudo-element */
 .participants-section ul li::before {
   display: none;
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,8 @@
+{
+  "teachers": [
+    {
+      "username": "teacher",
+      "password": "plain:teacher123"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR implements issue #5 by adding an admin mode so only authenticated teachers can register or unregister students from extracurricular activities.

## Changes

- add teacher authentication with login, logout, and auth status endpoints
- protect signup and unregister endpoints behind teacher auth
- add `teachers.json` for teacher credentials
- hash plain-text teacher passwords automatically on first startup
- add login UI in the header with a modal-based teacher sign-in flow
- hide registration and unregister controls unless a teacher is logged in
- add `passlib[bcrypt]` for secure password hashing

## Default teacher account

- username: `teacher`
- password: `teacher123`

## Closes

Closes #5